### PR TITLE
Quickfixes

### DIFF
--- a/src/eu/shooktea/vmsm/view/controller/mysql/TabScreen.java
+++ b/src/eu/shooktea/vmsm/view/controller/mysql/TabScreen.java
@@ -2,6 +2,7 @@ package eu.shooktea.vmsm.view.controller.mysql;
 
 import com.jcraft.jsch.JSchException;
 import eu.shooktea.sqlformatter.SqlFormatter;
+import eu.shooktea.vmsm.VM;
 import eu.shooktea.vmsm.module.mysql.*;
 import eu.shooktea.vmsm.view.StageController;
 import eu.shooktea.vmsm.view.View;
@@ -46,10 +47,11 @@ public class TabScreen implements StageController {
         availableFieldsTable.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
         MySQL sql = MySQL.getModuleByName("MySQL");
         connection = sql.createConnection();
+        String databaseName = sql.getStringSetting(VM.getOrThrow(), "database");
         try {
             connection.open();
             String query =
-                    "SELECT `TABLE_NAME`, `TABLE_ROWS` FROM `information_schema`.`TABLES` WHERE `TABLE_SCHEMA`='energa'";
+                    "SELECT `TABLE_NAME`, `TABLE_ROWS` FROM `information_schema`.`TABLES` WHERE `TABLE_SCHEMA`='" + databaseName + "'";
             setTablesListContent(new TableContent(connection.query(query)));
         } catch (JSchException | SQLException e) {
             e.printStackTrace();

--- a/src/eu/shooktea/vmsm/view/fxml/mysql/TabScreen.fxml
+++ b/src/eu/shooktea/vmsm/view/fxml/mysql/TabScreen.fxml
@@ -111,7 +111,7 @@
                <content>
                   <VBox>
                      <children>
-                        <TitledPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="200.0" text="Available fields" VBox.vgrow="NEVER">
+                        <TitledPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" text="Available fields" VBox.vgrow="NEVER">
                            <content>
                               <TableView fx:id="availableFieldsTable" onMouseClicked="#queryFieldsClicked" prefHeight="200.0" prefWidth="200.0">
                                 <columns>
@@ -128,7 +128,7 @@
                            <content>
                               <VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308">
                                  <children>
-                                    <TextArea fx:id="queryField" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" promptText="SELECT * FROM `table_name`" wrapText="true" VBox.vgrow="ALWAYS" onKeyReleased="#queryKeyReleased">
+                                    <TextArea fx:id="queryField" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" onKeyReleased="#queryKeyReleased" promptText="SELECT * FROM `table_name`" wrapText="true" VBox.vgrow="ALWAYS">
                                        <font>
                                           <Font name="Monospaced Regular" size="13.0" />
                                        </font>
@@ -138,7 +138,7 @@
                                           <Button defaultButton="true" mnemonicParsing="false" onAction="#runQueryField" text="Run query" />
                                            <Button mnemonicParsing="false" onAction="#formatQuery" text="Format query">
                                                <HBox.margin>
-                                                   <Insets left="10.0"/>
+                                                   <Insets left="10.0" />
                                                </HBox.margin>
                                            </Button>
                                        </children>


### PR DESCRIPTION
Quickfix for MySQL GUI:
* Using database name from configuration instead of hardcoded test database name when loading list of tables,
* "Available fields" now actually takes less space when collapsing
